### PR TITLE
update to current heads of cgmath, glium, and glutin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ bitflags = "0.1.1"
 libc = "0.1.5"
 
 [dependencies.glutin]
-version = "0.0.22"
+version = "0.1.3"
 optional = true
 
 [target.i686-pc-windows-gnu.dependencies]
@@ -29,7 +29,7 @@ winapi = "0.1.17"
 kernel32-sys = "0.1.0"
 
 [dev-dependencies.glium]
-version = "0.2.1"
+version = "0.3.5"
 default-features = false
 features = ["gl_read_buffer", "gl_depth_textures"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ bitflags = "0.1.1"
 libc = "0.1.5"
 
 [dependencies.glutin]
-version = "0.1.3"
+version = "^0.1"
 optional = true
 
 [target.i686-pc-windows-gnu.dependencies]
@@ -29,10 +29,10 @@ winapi = "0.1.17"
 kernel32-sys = "0.1.0"
 
 [dev-dependencies.glium]
-version = "0.3.5"
+version = "^0.3"
 default-features = false
 features = ["gl_read_buffer", "gl_depth_textures"]
 
 [dev-dependencies.cgmath]
+version = "^0.1"
 git = "https://github.com/bjz/cgmath-rs"
-branch = "rust-1.0"

--- a/examples/scene.rs
+++ b/examples/scene.rs
@@ -5,7 +5,7 @@ extern crate libc;
 extern crate rovr;
 
 use std::string;
-use cgmath::{ToMatrix4, Matrix, Point, FixedArray, Vector};
+use cgmath::{Matrix, Point, FixedArray, Vector};
 
 fn main() {
     use glium::DisplayBuild;
@@ -28,7 +28,7 @@ fn main() {
     let display = builder
         .with_title(string::String::from("Cube"))
         .with_vsync()
-        .with_gl_version((4, 1))
+        .with_gl(glutin::GlRequest::Specific(glutin::Api::OpenGl, (4, 1)))
         .build_glium()
         .ok().expect("Unable to build Window");
 
@@ -95,12 +95,14 @@ fn display_loop<'a, F: Fn(&cgmath::Matrix4<f32>, &mut glium::framebuffer::Simple
                 let center = cgmath::Point3::from_vec(&camera_position.add_v(&direction));
 
                 let orientation_mat = {
-                    let (orientation_s, ref orientation_v) = pose.orientation;
-                    cgmath::Quaternion::from_sv(orientation_s,
-                                                *cgmath::Vector3::from_fixed_ref(orientation_v))
-                        .to_matrix4()
-                        .invert().unwrap()
+                    let mat: cgmath::Matrix4<_> = {
+                        let (orientation_s, ref orientation_v) = pose.orientation;
+                        cgmath::Quaternion::from_sv(orientation_s,
+                            *cgmath::Vector3::from_fixed_ref(orientation_v))
+                    }.into();
+                    mat.invert().unwrap()
                 };
+
                 let eye_transform = *cgmath::Matrix4::from_fixed_ref(&projection) *
                     orientation_mat *
                     cgmath::Matrix4::look_at(&cgmath::Point::from_vec(&camera_position),


### PR DESCRIPTION
Wrote, built, and tested these changes on OS X 10.10.3 with rustc 1.0.0-beta.4 and cargo 0.2.0-nightly. Current versions of dependencies are cgmath 0.1.5, glium 0.3.6, and glutin 0.1.3.
